### PR TITLE
Handle missing AWS dependencies gracefully

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,14 +11,25 @@ import typing as t
 
 import pandas as pd
 import streamlit as st
-import boto3
-import botocore
+
+try:  # Optional AWS dependencies
+    import boto3
+    import botocore
+except ModuleNotFoundError:
+    boto3 = None  # type: ignore[assignment]
+    botocore = None  # type: ignore[assignment]
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Page
 # ──────────────────────────────────────────────────────────────────────────────
 st.set_page_config(page_title="Compliance Ingestion (S3-only)", page_icon="✅", layout="wide")
 st.title("✅ Distributor Reports — Compliance Intake (Streamlit • S3)")
+
+if boto3 is None or botocore is None:
+    st.error(
+        "Missing AWS dependencies. Install `boto3` and `botocore` to enable S3 uploads."
+    )
+    st.stop()
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Config via st.secrets (S3 only)


### PR DESCRIPTION
## Summary
- avoid app crash when `boto3`/`botocore` aren't installed
- surface a Streamlit error prompting users to install AWS dependencies

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c07e2b75988320a565222a2cf1bad6